### PR TITLE
Fix defect: java process exits on playbook exit

### DIFF
--- a/library/selenium
+++ b/library/selenium
@@ -205,6 +205,9 @@ def start(module):
                                                           role,
                                                           args,
                                                           log_file)
+
+        os.setsid()
+
         #print cmd
         rc = os.system(cmd)
 


### PR DESCRIPTION
By default, the java process otherwise seems to receive a signal when
its parent process exits. The java process then exits also.