### PR TITLE
Fix javaargs option wasn't loaded as a list.

### DIFF
--- a/library/selenium
+++ b/library/selenium
@@ -323,7 +323,7 @@ def main():
             args=dict(required=False, default=''),
             java=dict(required=False, default='/usr/bin/java'),
             logfile=dict(required=False, default='./selenium.log'),
-            javaargs=dict(required=False, default=''),
+            javaargs=dict(required=False, default=[], type='list'),
         ),
 
         supports_check_mode=False,


### PR DESCRIPTION
### When:
javaargs option is a list

    javaargs:
      - "Dwebdriver.chrome.driver=/bin/chromedriver"

### What:
The entire list was loaded as one string and led to unexpected Java options:

    { 'javaargs': \"['Dwebdriver.chrome.driver=/bin/chromedriver']\" }

### Fix:
The committed codes load javaargs as a list of strings:

    { 'javaargs': ['Dwebdriver.chrome.driver=/bin/chromedriver'] }