### PR TITLE
[arguments]: specify args to be of type 'dict'

### DIFF
--- a/library/selenium
+++ b/library/selenium
@@ -320,7 +320,7 @@ def main():
             version=dict(default='3.8.1'),
             path=dict(default='.'),
             force=dict(default=False, type='bool'),
-            args=dict(required=False, default=''),
+            args=dict(required=False, default='', type='dict'),
             java=dict(required=False, default='/usr/bin/java'),
             logfile=dict(required=False, default='./selenium.log'),
             javaargs=dict(required=False, default=[], type='list'),


### PR DESCRIPTION
Ansible now treat complex arguments as string unless specified otherwise.

The example
```yaml
- name: Restart a running node that was listening on a previous port
  selenium:
    role: node
    state: restarted
    args:
      hubUrl: http://0.0.0.0:4445
```
fails with a python error stating that module.params['args'] of type str has no attribute 'iteritems'